### PR TITLE
Added .handlebars and .hbs as valid file extensions

### DIFF
--- a/main.js
+++ b/main.js
@@ -239,7 +239,7 @@ define(function (require, exports, module) {
 	LanguageManager.defineLanguage("handlebars", {
 		"name": "handlebars",
 		"mode": "handlebars",
-		"fileExtensions": ["hbr"],
+		"fileExtensions": ["hbr", "handlebars", "hbs"],
 		"blockComment": ["<!--", "-->"]
 	});
 });


### PR DESCRIPTION
The official handlebars library lists .handlebars and .hbs as their fileextensions (though you have to go into the code to find it, see below). This PR adds .handlebars and .hbs next to .hbr (which I hadn't seen until I checked this plugin).

https://github.com/wycats/handlebars.js/blob/3f71fde15517b9053f92a0c5697f9681585d4b0f/lib/index.js
