### PR TITLE
Capitalise highlighter's name

### DIFF
--- a/main.js
+++ b/main.js
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
 	}
 
 	LanguageManager.defineLanguage("handlebars", {
-		"name": "handlebars",
+		"name": "Handlebars",
 		"mode": "handlebars",
 		"fileExtensions": fileExtensions,
 		"blockComment": ["{{!--", "--}}"]


### PR DESCRIPTION
For consistency with Bracket's built-in highlighters (HTML, CSS,
JavaScript, Markdown, Python, etc.)
